### PR TITLE
enable php 8.0 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.0"
+    "php": "^7.0|^8.0"
   },
   "suggest": {
     "ext-mqseries": "To actually use this library, you'll have to install the custom version of extension mqseries"


### PR DESCRIPTION
To be able to use this library in a project that specifiy php 8.0  (or higher) support in composer.json, this lib also need to state it supports php >=8.0. 

To my knowledge, and testing, there is nothing in here thats not compatible with php 8.0 or 8.1, so I think adding this version to the composer.json and doing a new packagist release is all that is required for this to work?